### PR TITLE
Use a FFILibrary subclass for selecting the llvm library name

### DIFF
--- a/src/LLVMDisassembler/LLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LLVMDisassembler.class.st
@@ -87,8 +87,7 @@ LLVMDisassembler class >> createDisassemblerForTriple: aTripleName info: disInfo
 
 { #category : #resources }
 LLVMDisassembler class >> ffiLibrary [
-
-	^ 'libLLVM.dylib' asFFILibrary
+	^ LibLLVMDisassembler
 ]
 
 { #category : #'instance-creation' }

--- a/src/LLVMDisassembler/LLVMTarget.class.st
+++ b/src/LLVMDisassembler/LLVMTarget.class.st
@@ -16,8 +16,7 @@ Class {
 
 { #category : #accessing }
 LLVMTarget class >> ffiLibrary [
-
-	^ 'libLLVM.dylib' asFFILibrary
+	^ LibLLVMDisassembler
 ]
 
 { #category : #accessing }

--- a/src/LLVMDisassembler/LibLLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LibLLVMDisassembler.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #LibLLVMDisassembler,
+	#superclass : #FFILibrary,
+	#category : #LLVMDisassembler
+}
+
+{ #category : #'accessing platform' }
+LibLLVMDisassembler >> macModuleName [
+	^ 'libLLVM.dylib'
+]
+
+{ #category : #'accessing platform' }
+LibLLVMDisassembler >> unixModuleName [
+	^ 'libLLVM-9.so'
+]
+
+{ #category : #'accessing platform' }
+LibLLVMDisassembler >> win32ModuleName [
+	^ 'libLLVM.dll'
+]


### PR DESCRIPTION
Do not hardcode libLLVM.dylib.