### PR TITLE
Add #knownMacPaths method to enable search of LLVM library in MacOS.

### DIFF
--- a/src/LLVMDisassembler-Tests/LibLLVMDisassemblerTest.class.st
+++ b/src/LLVMDisassembler-Tests/LibLLVMDisassemblerTest.class.st
@@ -1,0 +1,37 @@
+"
+A LibLLVMDisassemblerTest is a test class for testing the behavior of LibLLVMDisassembler
+"
+Class {
+	#name : #LibLLVMDisassemblerTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'llvmDisasm'
+	],
+	#category : #'LLVMDisassembler-Tests'
+}
+
+{ #category : #running }
+LibLLVMDisassemblerTest >> setUp [
+
+	super setUp.
+	llvmDisasm := LibLLVMDisassembler uniqueInstance.
+]
+
+{ #category : #tests }
+LibLLVMDisassemblerTest >> testKnownMacPaths [
+
+	self assert: (llvmDisasm knownMacPaths isKindOf: Collection).
+	self assert: llvmDisasm knownMacPaths notEmpty.
+	self assert: llvmDisasm knownMacPaths anyOne notEmpty.
+	self assert: llvmDisasm knownMacPaths anyOne isString.
+
+]
+
+{ #category : #tests }
+LibLLVMDisassemblerTest >> testMacModuleName [
+
+	(Smalltalk os isMacOSX or: [ Smalltalk os isMacOS ])
+		ifFalse: [ self skip ].
+	self assert: (llvmDisasm macModuleName isKindOf: String).
+	self deny: llvmDisasm macModuleName isEmpty.
+]

--- a/src/LLVMDisassembler-Tests/package.st
+++ b/src/LLVMDisassembler-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'LLVMDisassembler-Tests' }

--- a/src/LLVMDisassembler/LibLLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LibLLVMDisassembler.class.st
@@ -5,8 +5,19 @@ Class {
 }
 
 { #category : #'accessing platform' }
+LibLLVMDisassembler >> knownMacPaths [
+	"Answer a <Collection> of <String> each one representing known libLLVM locations (not necessarily present in the current system"
+	
+	^ { '/usr/local/opt/llvm/lib' }
+]
+
+{ #category : #'accessing platform' }
 LibLLVMDisassembler >> macModuleName [
-	^ 'libLLVM.dylib'
+	"Answer a <String> with the full path to the LLVM library"
+	
+	^ FFIMacLibraryFinder new
+		userPaths: self knownMacPaths;
+		findLibrary: 'libLLVM.dylib'
 ]
 
 { #category : #'accessing platform' }

--- a/src/LLVMDisassembler/LibLLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LibLLVMDisassembler.class.st
@@ -8,7 +8,10 @@ Class {
 LibLLVMDisassembler >> knownMacPaths [
 	"Answer a <Collection> of <String> each one representing known libLLVM locations (not necessarily present in the current system"
 	
-	^ { '/usr/local/opt/llvm/lib' }
+	^ { 
+		(LibC resultOfCommand: 'llvm-config --libdir') trimBoth .
+		'/usr/local/opt/llvm/lib' 
+		}
 ]
 
 { #category : #'accessing platform' }


### PR DESCRIPTION
This PR enables to search the LLVM library file by setting the #userPaths:
