### PR TITLE
Add new homebrew path

### DIFF
--- a/src/LLVMDisassembler/LibLLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LibLLVMDisassembler.class.st
@@ -9,8 +9,15 @@ LibLLVMDisassembler >> knownMacPaths [
 	"Answer a <Collection> of <String> each one representing known libLLVM locations (not necessarily present in the current system"
 	
 	^ { 
+		"Try finding the one using llvm-config"
 		(LibC resultOfCommand: 'llvm-config --libdir') trimBoth .
-		'/usr/local/opt/llvm/lib' 
+		
+		"New versions of homebrew put llvm in the following path,
+		not globally visible to avoid conflicts with the XCode's installation"
+		'/opt/homebrew/opt/llvm/lib'.
+		
+		"Old homebrew versions"
+		'/usr/local/opt/llvm/lib'
 		}
 ]
 


### PR DESCRIPTION
New versions of homebrew put llvm in the following path,
not globally visible to avoid conflicts with the XCode's installation

Mind to review @hernanmd?