### PR TITLE
Fix finalization and failure test

### DIFF
--- a/src/LLVMDisassembler-Tests/LLVMDisassemblerTests.class.st
+++ b/src/LLVMDisassembler-Tests/LLVMDisassemblerTests.class.st
@@ -171,6 +171,15 @@ LLVMDisassemblerTests >> testDisassembleWithAlternatePrinterVariantReturnsAltern
 ]
 
 { #category : #tests }
+LLVMDisassemblerTests >> testInitializeOnlyOnce [
+
+	| dis n |
+	dis := LLVMDisassembler i386.
+	n := WeakRegistry default keys occurrencesOf: dis.
+	self assert: n equals: 1
+]
+
+{ #category : #tests }
 LLVMDisassemblerTests >> testInvalidInstructionErrorContainsInvalidOpcode [
 
 	| dis |

--- a/src/LLVMDisassembler/LLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LLVMDisassembler.class.st
@@ -126,7 +126,6 @@ LLVMDisassembler class >> createDisassembler: aTripleString withCPU: aCPUString 
 		symbolLookupCallback: nil.
 	disassembler isNull ifTrue: [ 
 		self error: 'Could not instantiate disassembler for: ', aTripleString ].
-	disassembler initialize.
 	^ disassembler
 ]
 

--- a/src/LLVMDisassembler/LibLLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LibLLVMDisassembler.class.st
@@ -7,18 +7,24 @@ Class {
 { #category : #'accessing platform' }
 LibLLVMDisassembler >> knownMacPaths [
 	"Answer a <Collection> of <String> each one representing known libLLVM locations (not necessarily present in the current system"
-	
-	^ { 
-		"Try finding the one using llvm-config"
-		(LibC resultOfCommand: 'llvm-config --libdir') trimBoth .
-		
+
+	"Try finding the one using llvm-config"
+
+	| llvmConfigPaths brewPaths |
+	llvmConfigPaths := (LibC resultOfCommand: 'llvm-config --libdir')
+		                   ifEmpty: [ {  } ]
+		                   ifNotEmpty: [ :libdir | { libdir trimBoth } ].
+
+	brewPaths := {
 		"New versions of homebrew put llvm in the following path,
 		not globally visible to avoid conflicts with the XCode's installation"
 		'/opt/homebrew/opt/llvm/lib'.
 		
 		"Old homebrew versions"
 		'/usr/local/opt/llvm/lib'
-		}
+	 }.
+
+	^ llvmConfigPaths , brewPaths
 ]
 
 { #category : #'accessing platform' }


### PR DESCRIPTION
This PR fixes the finalization mechanism for LLVMDisassebler objects. The problem was that `initialize` method was called twice, so the same object had two ephemerons attached to free the same region of memory. 
It is the cause because this Druid's PR is failing: https://github.com/Alamvic/druid/pull/22

And it also fixed https://github.com/pharo-project/pharo-llvmDisassembler/issues/9. I changed how paths are collected and now it ignores the result from `llvm-config` if it's empty.