### PR TITLE
 Support for invalid instructions on RISC-V

### DIFF
--- a/src/LLVMDisassembler/LLVMARMDisassembler.class.st
+++ b/src/LLVMDisassembler/LLVMARMDisassembler.class.st
@@ -5,20 +5,6 @@ Class {
 	#package : 'LLVMDisassembler'
 }
 
-{ #category : 'disassembling' }
-LLVMARMDisassembler >> disassembleInstructionBytes: instructionBytes address: startAddress pc: pc [
-
-	| result |
-
-		[ result := self disassembleInstructionIn: instructionBytes pc: pc ]
-			on: LLVMInvalidInstructionError
-			do: [ ^ self newInvalidInstruction: instructionBytes address: startAddress ].
-		
-		result address: startAddress.
-		
-		^ result
-]
-
 { #category : 'factory' }
 LLVMARMDisassembler >> newInstruction [
 

--- a/src/LLVMDisassembler/LLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LLVMDisassembler.class.st
@@ -201,7 +201,7 @@ LLVMDisassembler >> disassembleInstructionBytes: instructionBytes address: start
 
 		[ result := self disassembleInstructionIn: instructionBytes pc: pc ]
 			on: LLVMInvalidInstructionError
-			do: [ ^ nil].
+			do: [ ^ self newInvalidInstruction: instructionBytes address: startAddress].
 		
 		result address: startAddress.
 		
@@ -301,6 +301,12 @@ LLVMDisassembler >> initialize [
 LLVMDisassembler >> newInstruction [
 
 	^ LLVMInstruction new
+]
+
+{ #category : 'configuring' }
+LLVMDisassembler >> newInvalidInstruction: instructionBytes address: address [
+	
+	^nil
 ]
 
 { #category : 'configuration' }

--- a/src/LLVMDisassembler/LLVMRV64Disassembler.class.st
+++ b/src/LLVMDisassembler/LLVMRV64Disassembler.class.st
@@ -10,3 +10,19 @@ LLVMRV64Disassembler >> newInstruction [
 
 	^ LLVMRV64Instruction new
 ]
+
+{ #category : 'instance creation' }
+LLVMRV64Disassembler >> newInvalidInstruction: bytes address: address [
+
+	| instruction hex |
+	instruction := self newInstruction.
+	instruction address: address.
+	instruction size: 4.
+
+	hex := bytes size >= 4
+		       ifTrue: [ (bytes integerAt: 1 size: 4 signed: false) hex ]
+		       ifFalse: [ bytes hex ].
+	instruction assembly: '.inst undefined ' , hex.
+
+	^ instruction
+]


### PR DESCRIPTION
refactoring of the base `disassembleInstructionBytes:address:pc:` from ARM to the main disassembler, addition of overloaded `newInvalidInstruction:address:` for RV64, like ARM. It still returns nil by default for the other archs