### PR TITLE
Reuse the temporary buffer when disassembling code

### DIFF
--- a/src/LLVMDisassembler/LLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LLVMDisassembler.class.st
@@ -24,7 +24,8 @@ Class {
 	#superclass : 'FFIExternalObject',
 	#instVars : [
 		'options',
-		'tmpBuf'
+		'instructionStringBuf',
+		'instructionBytesBuf'
 	],
 	#category : 'LLVMDisassembler',
 	#package : 'LLVMDisassembler'
@@ -220,15 +221,14 @@ LLVMDisassembler >> disassembleInstructionIn: bytes bufferSize: bytesSize pc: pc
 { #category : 'disassembling' }
 LLVMDisassembler >> disassembleInstructionIn: bytes pc: pc [
 
-	| string opsize |
-	string := self tmpBufOfAtLeast: 255.
-	string from: 1 to: 255 put: 0.
+	| opsize |
+	instructionStringBuf from: 1 to: 255 put: 0.
 	opsize := self
 		disassembleInstructionIn: bytes
 		bufferSize: bytes size
 		pc: pc
-		outString: string
-		outStringSize: string size.
+		outString: instructionStringBuf
+		outStringSize: instructionStringBuf size.
 		
 	opsize = 0 ifTrue: [ 
 		LLVMInvalidInstructionError new
@@ -236,7 +236,7 @@ LLVMDisassembler >> disassembleInstructionIn: bytes pc: pc [
 			signal ].
 	
 	^ self newInstruction
-		assembly: (string utf8Decoded trimBoth: [ :char | char isSeparator | (char = Character null) ]);
+		assembly: (instructionStringBuf utf8Decoded trimBoth: [ :char | char isSeparator | (char = Character null) ]);
 		size: opsize;
 		yourself
 ]
@@ -244,18 +244,17 @@ LLVMDisassembler >> disassembleInstructionIn: bytes pc: pc [
 { #category : 'disassembling' }
 LLVMDisassembler >> disassembleNext: numberOfInstructions instructionsIn: bytes startAddress: startAddress pc: pc [
 
-	| instructions result offset instructionBytes |
+	| instructions result offset |
 	instructions := OrderedCollection new.
 	offset := 0.
-	[ instructions size < numberOfInstructions ] whileTrue: [ "assume 50 bytes tops per instruction"
-		instructionBytes := self tmpBufOfAtLeast: 50.
-		instructionBytes replaceFrom: 1
+	[ instructions size < numberOfInstructions ] whileTrue: [
+		instructionBytesBuf replaceFrom: 1
 			to: (50 min: (bytes size - offset))
 			with: bytes
 			startingAt: (offset + 1 min: bytes size).
 
 		result := self
-			          disassembleInstructionBytes: instructionBytes
+			          disassembleInstructionBytes: instructionBytesBuf
 			          address: startAddress + offset
 			          pc: pc.
 
@@ -298,6 +297,9 @@ LLVMDisassembler >> initialize [
 
 	"Should not call super initialize, because it will reinitialize the handle..."
 	options := 0.
+	"assume 50 bytes tops per instruction"
+	instructionBytesBuf := ByteArray new: 50.
+	instructionStringBuf  := ByteArray new: 255.
 	FinalizationRegistry default add: self
 ]
 
@@ -329,14 +331,6 @@ LLVMDisassembler >> setInstructionComments [
 LLVMDisassembler >> setOptions: options [
 
 	self ffiCall: #(int LLVMSetDisasmOptions(self, uint64 options))
-]
-
-{ #category : 'resources' }
-LLVMDisassembler >> tmpBufOfAtLeast: aSize [
-
-	(tmpBuf isNil or: [ tmpBuf size < aSize ])
-		ifTrue: [ tmpBuf := ByteArray newPinned: aSize ].
-	^ tmpBuf.
 ]
 
 { #category : 'configuring' }

--- a/src/LLVMDisassembler/LLVMDisassembler.class.st
+++ b/src/LLVMDisassembler/LLVMDisassembler.class.st
@@ -23,7 +23,8 @@ Class {
 	#name : 'LLVMDisassembler',
 	#superclass : 'FFIExternalObject',
 	#instVars : [
-		'options'
+		'options',
+		'tmpBuf'
 	],
 	#category : 'LLVMDisassembler',
 	#package : 'LLVMDisassembler'
@@ -220,7 +221,8 @@ LLVMDisassembler >> disassembleInstructionIn: bytes bufferSize: bytesSize pc: pc
 LLVMDisassembler >> disassembleInstructionIn: bytes pc: pc [
 
 	| string opsize |
-	string := ByteArray new: 255.
+	string := self tmpBufOfAtLeast: 255.
+	string from: 1 to: 255 put: 0.
 	opsize := self
 		disassembleInstructionIn: bytes
 		bufferSize: bytes size
@@ -246,9 +248,11 @@ LLVMDisassembler >> disassembleNext: numberOfInstructions instructionsIn: bytes 
 	instructions := OrderedCollection new.
 	offset := 0.
 	[ instructions size < numberOfInstructions ] whileTrue: [ "assume 50 bytes tops per instruction"
-		instructionBytes := bytes
-			                    copyFrom: (offset + 1 min: bytes size)
-			                    to: (offset + 50 min: bytes size).
+		instructionBytes := self tmpBufOfAtLeast: 50.
+		instructionBytes replaceFrom: 1
+			to: (50 min: (bytes size - offset))
+			with: bytes
+			startingAt: (offset + 1 min: bytes size).
 
 		result := self
 			          disassembleInstructionBytes: instructionBytes
@@ -325,6 +329,14 @@ LLVMDisassembler >> setInstructionComments [
 LLVMDisassembler >> setOptions: options [
 
 	self ffiCall: #(int LLVMSetDisasmOptions(self, uint64 options))
+]
+
+{ #category : 'resources' }
+LLVMDisassembler >> tmpBufOfAtLeast: aSize [
+
+	(tmpBuf isNil or: [ tmpBuf size < aSize ])
+		ifTrue: [ tmpBuf := ByteArray newPinned: aSize ].
+	^ tmpBuf.
 ]
 
 { #category : 'configuring' }


### PR DESCRIPTION
It does what it says on the tin.